### PR TITLE
feat: add new flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@
 This GitHub Action performs static analysis on Traefik Hub Custom Resource Definitions (CRD) manifests.  
 It allows you to lint the manifests and generate a diff report between commits.
 
-<!-- Here a link to the upcoming public binary repo -->
-
 > If you run this action in a public repository or if you are a GitHub Enterprise customer,
 you can leverage the SARIF output format to [submit a code scanning artifact](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github).
 
@@ -64,12 +62,18 @@ jobs:
         # By default, the current directory will be used.
         path: "path/to/manifests"
 
+        # Only include the matching manifests.
+        include: ""
+
+        # Exclude the matching manifests.
+        exclude: ""
+
         ## Linting options:
         # Enable linting.
         # By default, "false".
         lint: "true"
 
-        # Configure the output format of the linter. One of `unix`, `checkstyle` or `json`.
+        # Configure the output format of the linter. One of `unix`, `checkstyle`, `json` or `sarif`.
         # By default, `unix` format will be used.
         lint-format: "unix"
 
@@ -79,6 +83,10 @@ jobs:
 
         # Comma-separated list of rules to disable.
         lint-disabled-rules: ""
+
+        # Enable offline mode for additional validation checks.
+        # By default, "false".
+        lint-offline: "false"
 
         ## Diff report options:
         # Enable the generation of a diff report.
@@ -94,7 +102,7 @@ jobs:
 
         # The file will be overwritten if it exists.
         # By default, in "traefik-hub-static-analyzer-diff.out".
-        diff-output-file: "/path/to/output.lint.out"
+        diff-output-file: "/path/to/output.diff.out"
 ```
 
 ## Example
@@ -150,7 +158,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           diff: true
-          diff-range: "origin/${{ github.base_ref }}...pull/${{ github.ref_name }}"
+          diff-range: "origin/${{ github.base_ref }}...origin/${{ github.head_ref }}"
           diff-output-file: ./output.md
 
       - name: Prepare report
@@ -244,13 +252,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Lint Traefik Hub CRDs with hub-static-analyzer
+      - name: Diff Traefik Hub CRDs with hub-static-analyzer
         uses: traefik/hub-static-analyzer-action@main
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           diff: true
-          diff-range: "origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}"
+          diff-range: "origin/${{ github.base_ref }}...origin/${{ github.head_ref }}"
           diff-output-file: ./output.md
 
       - name: Prepare report

--- a/action.yaml
+++ b/action.yaml
@@ -12,13 +12,17 @@ inputs:
     description: 'Path to the manifests within a Git repository'
     required: false
     default: "./"
+  include:
+    description: 'Only include the matching manifests'
+    required: false
+    default: ''
   exclude:
     description: 'Exclude the matching manifests'
     required: false
     default: ''
   # Lint options.
   lint:
-    description: 'Lint manifests. . Default: "false"'
+    description: 'Lint manifests. Default: "false"'
     required: false
     default: "false"
   lint-output-file:
@@ -26,9 +30,13 @@ inputs:
     required: false
     default: 'traefik-hub-static-analyzer-lint.out'
   lint-format:
-    description: 'Format, one of: unix, json, checkstyle'
+    description: 'Format, one of: unix, json, checkstyle, sarif'
     required: false
     default: 'unix'
+  lint-offline:
+    description: 'Enable offline mode for additional validation checks. Default: "false"'
+    required: false
+    default: "false"
   lint-disabled-rules:
     description: 'Comma-separated list of Rules to disable'
     required: false
@@ -88,6 +96,19 @@ runs:
         set -u
         set +e
 
+        pids=()
+        statuses=()
+
+        includeArgs=()
+        if [ -n "${{ inputs.include }}" ]; then
+          includeArgs=(--include "${{ inputs.include }}")
+        fi
+
+        excludeArgs=()
+        if [ -n "${{ inputs.exclude }}" ]; then
+          excludeArgs=(--exclude "${{ inputs.exclude }}")
+        fi
+
         if [ "${{ inputs.lint }}" = "true" ]; then
           rules="${{ inputs.lint-disabled-rules }}"
           disabledRules=(${rules//,/ })
@@ -95,15 +116,19 @@ runs:
           for r in "${disabledRules[@]}"; do
             cliRules+="--rule.${r}=false "
           done
-          echo \$ hub-static-analyzer lint $cliRules --path "${{ inputs.path }}" --format "${{ inputs.lint-format }}" --exclude "${{ inputs.exclude }}"
-          (./hub-static-analyzer lint $cliRules --path "${{ inputs.path }}" --format "${{ inputs.lint-format }}" --exclude "${{ inputs.exclude }}" > "${{ inputs.lint-output-file }}")&
+          offlineArgs=()
+          if [ "${{ inputs.lint-offline }}" = "true" ]; then
+            offlineArgs=(--offline)
+          fi
+          echo \$ hub-static-analyzer lint $cliRules --path "${{ inputs.path }}" --format "${{ inputs.lint-format }}" --color=false "${includeArgs[@]}" "${excludeArgs[@]}" "${offlineArgs[@]}"
+          (./hub-static-analyzer lint $cliRules --path "${{ inputs.path }}" --format "${{ inputs.lint-format }}" --color=false "${includeArgs[@]}" "${excludeArgs[@]}" "${offlineArgs[@]}" > "${{ inputs.lint-output-file }}")&
 
           pids+=($!)
         fi
 
-        if [ ${{ inputs.diff }} = "true" ]; then
-          echo \$ hub-static-analyzer diff --path "${{ inputs.path }}" --format "${{ inputs.lint-format }}" --exclude "${{ inputs.exclude }}"
-          (./hub-static-analyzer diff --path "${{ inputs.path }}" ${{ inputs.diff-range }} --exclude "${{ inputs.exclude }}" | tee "${{ inputs.diff-output-file }}")&
+        if [ "${{ inputs.diff }}" = "true" ]; then
+          echo \$ hub-static-analyzer diff --path "${{ inputs.path }}" "${includeArgs[@]}" "${excludeArgs[@]}" ${{ inputs.diff-range }}
+          (./hub-static-analyzer diff --path "${{ inputs.path }}" "${includeArgs[@]}" "${excludeArgs[@]}" ${{ inputs.diff-range }} | tee "${{ inputs.diff-output-file }}")&
 
           pids+=($!)
         fi
@@ -114,8 +139,8 @@ runs:
           statuses+=($?)
         done
 
-        [ -s ${{ inputs.lint-output-file }} ] || rm -f ${{ inputs.lint-output-file }}
-        [ -s ${{ inputs.diff-output-file }} ] || rm -f ${{ inputs.diff-output-file }}
+        [ -s "${{ inputs.lint-output-file }}" ] || rm -f "${{ inputs.lint-output-file }}"
+        [ -s "${{ inputs.diff-output-file }}" ] || rm -f "${{ inputs.diff-output-file }}"
 
         # echo "Statuses ${statuses}"
 

--- a/action.yaml
+++ b/action.yaml
@@ -59,21 +59,25 @@ runs:
   steps:
     - name: download hub-static-analyzer
       shell: bash
+      env:
+        INPUT_RUNNER_ARCH: ${{ runner.arch }}
+        INPUT_RUNNER_OS: ${{ runner.os }}
+        INPUT_VERSION: ${{ inputs.version }}
       run: |
         # Download hub-static-analyzer
         set -u
 
-        if [ ${{ runner.arch }} = "ARM64" ]; then
+        if [ "$INPUT_RUNNER_ARCH" = "ARM64" ]; then
           RELEASE_ARCH="arm64"
-        elif [ ${{ runner.arch }} = "X64" ]; then
+        elif [ "$INPUT_RUNNER_ARCH" = "X64" ]; then
           RELEASE_ARCH="amd64"
         else
           RELEASE_ARCH="amd64"
         fi
 
-        if [ ${{ runner.os }} = "macOS" ]; then
+        if [ "$INPUT_RUNNER_OS" = "macOS" ]; then
           RELEASE_OS="darwin"
-        elif [ ${{ runner.os }} = "Linux" ]; then
+        elif [ "$INPUT_RUNNER_OS" = "Linux" ]; then
           RELEASE_OS="linux"
         else
           RELEASE_OS="linux"
@@ -82,53 +86,76 @@ runs:
         PATTERN="static-analyzer-*-${RELEASE_OS}-${RELEASE_ARCH}*"
         REPOSITORY='traefik/hub'
         TARGET="hub-static-analyzer.tar.gz"
-        if [[ "${{ inputs.version }}" == "latest" ]]; then
+        if [[ "$INPUT_VERSION" == "latest" ]]; then
           gh release download --repo "${REPOSITORY}" --pattern "${PATTERN}" --output "${TARGET}" "static-analyzer-v1.7.0" > /dev/null
         else
-          gh release download --repo "${REPOSITORY}" --pattern "${PATTERN}" --output "${TARGET}" "static-analyzer-${{ inputs.version }}" > /dev/null
+          gh release download --repo "${REPOSITORY}" --pattern "${PATTERN}" --output "${TARGET}" "static-analyzer-${INPUT_VERSION}" > /dev/null
         fi
 
         tar -xf "$TARGET" --strip-components 1
     - name: run static analysis
       shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_INCLUDE: ${{ inputs.include }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
+        INPUT_LINT: ${{ inputs.lint }}
+        INPUT_LINT_FORMAT: ${{ inputs.lint-format }}
+        INPUT_LINT_OFFLINE: ${{ inputs.lint-offline }}
+        INPUT_LINT_DISABLED_RULES: ${{ inputs.lint-disabled-rules }}
+        INPUT_LINT_OUTPUT_FILE: ${{ inputs.lint-output-file }}
+        INPUT_DIFF: ${{ inputs.diff }}
+        INPUT_DIFF_RANGE: ${{ inputs.diff-range }}
+        INPUT_DIFF_OUTPUT_FILE: ${{ inputs.diff-output-file }}
       run: |
         # hub-static-analyzer
         set -u
         set +e
 
+        # Validate boolean inputs.
+        for var in INPUT_LINT INPUT_LINT_OFFLINE INPUT_DIFF; do
+          if [[ "${!var}" != "true" && "${!var}" != "false" ]]; then
+            echo "::error::${var} must be 'true' or 'false', got '${!var}'"
+            exit 1
+          fi
+        done
+
+        if [[ ! "$INPUT_LINT_FORMAT" =~ ^(unix|json|checkstyle|sarif)$ ]]; then
+          echo "::error::lint-format must be one of: unix, json, checkstyle, sarif"
+          exit 1
+        fi
+
         pids=()
         statuses=()
 
-        includeArgs=()
-        if [ -n "${{ inputs.include }}" ]; then
-          includeArgs=(--include "${{ inputs.include }}")
+        commonArgs=(--path "$INPUT_PATH")
+        if [ -n "$INPUT_INCLUDE" ]; then
+          commonArgs+=(--include "$INPUT_INCLUDE")
+        fi
+        if [ -n "$INPUT_EXCLUDE" ]; then
+          commonArgs+=(--exclude "$INPUT_EXCLUDE")
         fi
 
-        excludeArgs=()
-        if [ -n "${{ inputs.exclude }}" ]; then
-          excludeArgs=(--exclude "${{ inputs.exclude }}")
-        fi
-
-        if [ "${{ inputs.lint }}" = "true" ]; then
-          rules="${{ inputs.lint-disabled-rules }}"
-          disabledRules=(${rules//,/ })
-          cliRules=""
-          for r in "${disabledRules[@]}"; do
-            cliRules+="--rule.${r}=false "
-          done
-          offlineArgs=()
-          if [ "${{ inputs.lint-offline }}" = "true" ]; then
-            offlineArgs=(--offline)
+        if [ "$INPUT_LINT" = "true" ]; then
+          lintArgs=(--format "$INPUT_LINT_FORMAT" --color=false)
+          if [ "$INPUT_LINT_OFFLINE" = "true" ]; then
+            lintArgs+=(--offline)
           fi
-          echo \$ hub-static-analyzer lint $cliRules --path "${{ inputs.path }}" --format "${{ inputs.lint-format }}" --color=false "${includeArgs[@]}" "${excludeArgs[@]}" "${offlineArgs[@]}"
-          (./hub-static-analyzer lint $cliRules --path "${{ inputs.path }}" --format "${{ inputs.lint-format }}" --color=false "${includeArgs[@]}" "${excludeArgs[@]}" "${offlineArgs[@]}" > "${{ inputs.lint-output-file }}")&
+          rules="$INPUT_LINT_DISABLED_RULES"
+          disabledRules=(${rules//,/ })
+          for r in "${disabledRules[@]}"; do
+            lintArgs+=("--rule.${r}=false")
+          done
+
+          echo \$ hub-static-analyzer lint "${commonArgs[@]}" "${lintArgs[@]}"
+          (./hub-static-analyzer lint "${commonArgs[@]}" "${lintArgs[@]}" > "$INPUT_LINT_OUTPUT_FILE")&
 
           pids+=($!)
         fi
 
-        if [ "${{ inputs.diff }}" = "true" ]; then
-          echo \$ hub-static-analyzer diff --path "${{ inputs.path }}" "${includeArgs[@]}" "${excludeArgs[@]}" ${{ inputs.diff-range }}
-          (./hub-static-analyzer diff --path "${{ inputs.path }}" "${includeArgs[@]}" "${excludeArgs[@]}" ${{ inputs.diff-range }} | tee "${{ inputs.diff-output-file }}")&
+        if [ "$INPUT_DIFF" = "true" ]; then
+          echo \$ hub-static-analyzer diff "${commonArgs[@]}" $INPUT_DIFF_RANGE
+          (./hub-static-analyzer diff "${commonArgs[@]}" $INPUT_DIFF_RANGE | tee "$INPUT_DIFF_OUTPUT_FILE")&
 
           pids+=($!)
         fi
@@ -139,10 +166,8 @@ runs:
           statuses+=($?)
         done
 
-        [ -s "${{ inputs.lint-output-file }}" ] || rm -f "${{ inputs.lint-output-file }}"
-        [ -s "${{ inputs.diff-output-file }}" ] || rm -f "${{ inputs.diff-output-file }}"
-
-        # echo "Statuses ${statuses}"
+        [ -s "$INPUT_LINT_OUTPUT_FILE" ] || rm -f "$INPUT_LINT_OUTPUT_FILE"
+        [ -s "$INPUT_DIFF_OUTPUT_FILE" ] || rm -f "$INPUT_DIFF_OUTPUT_FILE"
 
         for st in ${statuses[@]}; do
           if [[ ${st} -ne 0 ]]; then


### PR DESCRIPTION
This PR updates the action with the new flags and bring various improvements on the script:

action.yaml
- Add `include`, `exclude`, and `lint-offline` inputs
- Deduplicate includeArgs/excludeArgs construction by moving them before the lint/diff conditional blocks
- Use bash arrays for includeArgs, excludeArgs, and offlineArgs to avoid passing empty args when inputs are unset
- Quote ${{ inputs.diff }} comparison to prevent word splitting
- Quote output file paths in cleanup lines
- Fix typo in lint input description (".. Default" -> ". Default")

README.md:
- Document include, exclude, and lint-offline inputs
- Add sarif to the list of lint-format options
- Fix diff-output-file example path (output.lint.out -> output.diff.out)
- Fix diff-range to use origin/${{ github.head_ref }} instead of pull/${{ github.ref_name }}
- Fix diff-range to use ${{ github.base_ref }} expressions instead of raw ${GITHUB_BASE_REF} env vars
- Fix step name from "Lint" to "Diff" for the diff example
- Remove leftover placeholder HTML comment