### PR TITLE
chore: update with hub-static-analyzer-v1.9.2

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -87,7 +87,7 @@ runs:
         REPOSITORY='traefik/hub'
         TARGET="hub-static-analyzer.tar.gz"
         if [[ "$INPUT_VERSION" == "latest" ]]; then
-          gh release download --repo "${REPOSITORY}" --pattern "${PATTERN}" --output "${TARGET}" "static-analyzer-v1.9.1" > /dev/null
+          gh release download --repo "${REPOSITORY}" --pattern "${PATTERN}" --output "${TARGET}" "static-analyzer-v1.9.2" > /dev/null
         else
           gh release download --repo "${REPOSITORY}" --pattern "${PATTERN}" --output "${TARGET}" "static-analyzer-${INPUT_VERSION}" > /dev/null
         fi


### PR DESCRIPTION
# What does it do ?

Update this action with the latest version of `hub-static-analyzer`